### PR TITLE
Stop linkifying comments

### DIFF
--- a/link.js
+++ b/link.js
@@ -24,7 +24,7 @@ function linkifyJiraKeys() {
       return;
     }
 
-    var selectors = ['.js-issue-title', '.comment-body'];
+    var selectors = ['.js-issue-title'];
 
     selectors.forEach(function (selector) {
       var elements = document.querySelectorAll(selector);


### PR DESCRIPTION
Attempting to link comments has caused me various pains and bugs, and it delivers relatively little upside, since I almost always try to put the Jira issue number in the PR title. Therefore, stop trying to linkify comments.