### PR TITLE
[GitHub Actions] Provide path ('.') for Prettier check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install JavaScript packages
         run: pnpm install --frozen-lockfile
       - name: Run Prettier
-        run: ./node_modules/.bin/prettier --check
+        run: ./node_modules/.bin/prettier --check .
       - name: Run ESLint
         run: ./node_modules/.bin/eslint --max-warnings 0 .
       - name: Run web-ext


### PR DESCRIPTION
I think that this is required? Not sure if this was working without the path.